### PR TITLE
Allow for image filenames with spaces in images.txt

### DIFF
--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -1566,7 +1566,7 @@ void Reconstruction::ReadImagesText(const std::string& path) {
     image.SetCameraId(std::stoul(item));
 
     // NAME
-    std::getline(line_stream1, item, ' ');
+    std::getline(line_stream1, item);
     image.SetName(item);
 
     // POINTS2D


### PR DESCRIPTION
filename is the last item on the line, so we can just read to the end of the line instead of to the next space